### PR TITLE
일정 관리 API 연동

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -44,4 +45,14 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Import the Firebase BoM
+    implementation platform('com.google.firebase:firebase-bom:33.6.0')
+    implementation 'com.google.firebase:firebase-analytics'
+
+    // TODO: Add the dependencies for Firebase products you want to use
+    // When using the BoM, don't specify versions in Firebase dependencies
+    // https://firebase.google.com/docs/android/setup#available-libraries
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,11 @@
+plugins {
+    // ...
+
+    // Add the dependency for the Google services Gradle plugin
+    id 'com.google.gms.google-services' version '4.4.2' apply false
+
+}
+
 allprojects {
     repositories {
         google()
@@ -16,3 +24,4 @@ subprojects {
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }
+

--- a/lib/ScheduleScreen.dart
+++ b/lib/ScheduleScreen.dart
@@ -1,11 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:overture/models/schedule_model_files/schedule_model.dart';
 import 'package:overture/screens/schedule_view.dart';
+import 'package:overture/service/FirestoreScheduleService.dart';
+import 'package:overture/service/ScheduleDto.dart';
+import 'package:provider/provider.dart';
 
 class ScheduleScreen extends StatelessWidget {
-  const ScheduleScreen({super.key});
+  final FirestoreScheduleService service = FirestoreScheduleService();
+  List<Schedule> scheduleList = [];
+  List<ScheduleDto> fetchSchedule = [];
+  ScheduleScreen({super.key});
+
+  Future<void> fetchSchedules(BuildContext context) async {
+    final scheduleModel = Provider.of<ScheduleModel>(context);
+    fetchSchedule = await service.getAllSchedules(); // 비동기 작업 결과 가져오기
+    for (ScheduleDto schedule in fetchSchedule) {
+      scheduleList.add(Schedule(
+        id: schedule.scheduleId,
+        title: schedule.title,
+        content: schedule.content,
+        time: schedule.time,
+        place: schedule.place, // 'location'으로 수정 (place와 혼동 방지)
+      ));
+    }
+    if(scheduleList.isNotEmpty) scheduleModel.addScheduleList(scheduleList);
+  }
 
   @override
   Widget build(BuildContext context) {
+    fetchSchedules(context);
     return Scaffold(
       body: ScheduleView(
         startDate: DateTime.now(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -17,7 +18,8 @@ import 'MenuTranslationScreen/MenuTranslationScreen.dart';
 //TODO main icon 움직이게
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized;
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   await dotenv.load(fileName: ".env");
   await initializeDateFormatting('ko_KR', null); // 로케일 데이터 초기화
   HttpOverrides.global = NoCheckCertificateHttpOverrides();
@@ -42,6 +44,11 @@ class MyApp extends StatelessWidget {
   }
 }
 
+Future<void> initializeDefault() async {
+  FirebaseApp app = await Firebase.initializeApp();
+  print('Initialized default app $app');
+}
+
 class NoCheckCertificateHttpOverrides extends HttpOverrides {
   @override
   HttpClient createHttpClient(SecurityContext? context) {
@@ -64,7 +71,7 @@ class _HomeScreenState extends State<HomeScreen> {
   final List<Widget> _screens = [
     const HomeScreenBody(),
     const CheckListScreen(),
-    const ScheduleScreen(),
+    ScheduleScreen(),
     const TravelScreen(),
     const SettingScreen(),
     const MapScreen()

--- a/lib/models/schedule_model_files/schedule_model.dart
+++ b/lib/models/schedule_model_files/schedule_model.dart
@@ -48,7 +48,7 @@ class ScheduleModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  List<Schedule> schedulesForDate(DateTime selectedDate) {
+  static List<Schedule> schedulesForDate(DateTime selectedDate, List<Schedule> _schedules) {
     return _schedules.where((schedule) {
       try {
         final scheduleDate = DateFormat('yyyy-MM-dd HH:mm').parse(schedule.time);

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:overture/models/schedule_model_files/schedule_model.dart';
+import 'package:overture/service/FirestoreScheduleService.dart';
+import 'package:overture/service/ScheduleDto.dart';
 import 'package:provider/provider.dart';
 import '../widgets/day_selector.dart';
 import '../widgets/schedule_item.dart';
@@ -18,6 +20,7 @@ class ScheduleView extends StatefulWidget {
 }
 
 class _ScheduleViewState extends State<ScheduleView> {
+  final FirestoreScheduleService service = FirestoreScheduleService();
   int _selectedDay = 1;
   DateTime? _selectedDate = DateTime.now();
   String selectedFilter = 'Date';
@@ -40,6 +43,7 @@ class _ScheduleViewState extends State<ScheduleView> {
 
   @override
   Widget build(BuildContext context) {
+    final scheduleModel2 = Provider.of<ScheduleModel>(context);
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
@@ -94,7 +98,7 @@ class _ScheduleViewState extends State<ScheduleView> {
           Expanded(
             child: Consumer<ScheduleModel>(
               builder: (context, scheduleModel, child) {
-                originScheduleModel = scheduleModel;
+                originScheduleModel = scheduleModel2;
                 return filteredScheduleModel.schedules.isEmpty
                     ? const Column(
                         mainAxisAlignment: MainAxisAlignment.center,
@@ -191,6 +195,7 @@ class _ScheduleViewState extends State<ScheduleView> {
                         Provider.of<ScheduleModel>(context, listen: false);
                     if (schedule == null) {
                       scheduleModel.addSchedule(newSchedule);
+                      service.addMultipleSchedules([ScheduleDto.toScheduleDto(newSchedule, '1')]);
                     } else {
                       scheduleModel.editSchedule(newSchedule);
                     }

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -45,7 +45,7 @@ class _ScheduleViewState extends State<ScheduleView> {
   @override
   Widget build(BuildContext context) {
     final scheduleModel = Provider.of<ScheduleModel>(context);
-
+    print("build scheduleModel : ${scheduleModel.schedules.length}");
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
@@ -67,7 +67,9 @@ class _ScheduleViewState extends State<ScheduleView> {
                   widget.startDate.month,
                   widget.startDate.day + _selectedDay - 1,
                 );
-                filteredScheduleModel.addScheduleList(ScheduleModel.schedulesForDate(_selectedDate!, originScheduleList));
+                filteredScheduleModel.addScheduleList(
+                    ScheduleModel.schedulesForDate(
+                        _selectedDate!, originScheduleList));
                 print("Day Selected");
               });
             },
@@ -78,6 +80,7 @@ class _ScheduleViewState extends State<ScheduleView> {
               PopupMenuButton<String>(
                 onSelected: (value) {
                   _sortItems(value); // 정렬 함수 호출
+                  print("call _sortItems");
                 },
                 itemBuilder: (BuildContext context) => [
                   PopupMenuItem(
@@ -98,50 +101,56 @@ class _ScheduleViewState extends State<ScheduleView> {
             child: Consumer<ScheduleModel>(
               builder: (context, scheduleModel, child) {
                 originScheduleList = scheduleModel.schedules;
-                print("originScheduleModel length: ${originScheduleList.length}");
-                print("scheduleModel length: ${scheduleModel.schedules.length}");
-                    if (originScheduleList.length == 159) {
-                      print("First 159");
-                    }
+                print(
+                    "originScheduleModel length: ${originScheduleList.length}");
+                print(
+                    "scheduleModel length: ${scheduleModel.schedules.length}");
+                if (originScheduleList.length == 159) {
+                  print("First 159");
+                }
                 return filteredScheduleModel.schedules.isEmpty
                     ? const Center(
-                  child: Text(
-                    "이 날짜에 예정된 일정이 없습니다.",
-                    style: TextStyle(color: Color(0xff5F5F5F)),
-                  ),
-                )
+                        child: Text(
+                          "이 날짜에 예정된 일정이 없습니다.",
+                          style: TextStyle(color: Color(0xff5F5F5F)),
+                        ),
+                      )
                     : ListView.builder(
-                  itemCount: filteredScheduleModel.schedules.length,
-                  itemBuilder: (context, index) {
-                    print(filteredScheduleModel.schedules.length);
-                    final schedule = filteredScheduleModel.schedules[index];
-                    return Padding(
-                      padding: const EdgeInsets.all(15),
-                      child: ScheduleItem(
-                        schedule: schedule,
-                        onEdit: () {
-                          _showScheduleForm(context, schedule: schedule);
-                        },
-                        onDelete: () {
-                          filteredScheduleModel.deleteSchedule(schedule.id);
-                          scheduleModel.deleteSchedule(schedule.id);
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: const Text('일정이 삭제되었습니다.'),
-                              action: SnackBarAction(
-                                label: '되돌리기',
-                                onPressed: () {
-                                  filteredScheduleModel.addSchedule(schedule);
-                                  scheduleModel.addSchedule(schedule);
-                                },
-                              ),
+                        itemCount: filteredScheduleModel.schedules.length,
+                        itemBuilder: (context, index) {
+                          print(filteredScheduleModel.schedules.length);
+                          final schedule =
+                              filteredScheduleModel.schedules[index];
+                          return Padding(
+                            padding: const EdgeInsets.all(15),
+                            child: ScheduleItem(
+                              schedule: schedule,
+                              onEdit: () {
+                                _showScheduleForm(context, schedule: schedule);
+                              },
+                              onDelete: () {
+                                filteredScheduleModel
+                                    .deleteSchedule(schedule.id);
+                                scheduleModel.deleteSchedule(schedule.id);
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: const Text('일정이 삭제되었습니다.'),
+                                    action: SnackBarAction(
+                                      label: '되돌리기',
+                                      onPressed: () {
+                                        filteredScheduleModel
+                                            .addSchedule(schedule);
+                                        scheduleModel.addSchedule(schedule);
+                                        print("call 되돌리기");
+                                      },
+                                    ),
+                                  ),
+                                );
+                              },
                             ),
                           );
                         },
-                      ),
-                    );
-                  },
-                );
+                      );
               },
             ),
           ),
@@ -181,20 +190,24 @@ class _ScheduleViewState extends State<ScheduleView> {
               Container(height: 50, color: Colors.transparent),
               Padding(
                 padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom, // 키보드 높이만큼 패딩 추가
+                  bottom: MediaQuery.of(context)
+                      .viewInsets
+                      .bottom, // 키보드 높이만큼 패딩 추가
                 ),
                 child: ScheduleForm(
                   selectedDate: _selectedDate!,
                   schedule: schedule,
                   onSubmit: (newSchedule) {
                     final scheduleModel =
-                    Provider.of<ScheduleModel>(context, listen: false);
+                        Provider.of<ScheduleModel>(context, listen: false);
                     if (schedule == null) {
                       // 중복된 일정을 추가하지 않도록 확인
                       if (!scheduleModel.schedules.contains(newSchedule)) {
                         scheduleModel.addSchedule(newSchedule);
-                        print("scheduleModel length: ${scheduleModel.schedules.length}");
-                        service.addMultipleSchedules([ScheduleDto.toScheduleDto(newSchedule, '1')]);
+                        print(
+                            "scheduleModel length: ${scheduleModel.schedules.length}");
+                        service.addMultipleSchedules(
+                            [ScheduleDto.toScheduleDto(newSchedule, '1')]);
                       }
                     } else {
                       scheduleModel.editSchedule(newSchedule);

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -135,6 +135,7 @@ class _ScheduleViewState extends State<ScheduleView> {
                                 filteredScheduleModel
                                     .deleteSchedule(schedule.id);
                                 scheduleModel.deleteSchedule(schedule.id);
+                                service.deleteSchedule(schedule.id);
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(
                                     content: const Text('일정이 삭제되었습니다.'),
@@ -143,7 +144,8 @@ class _ScheduleViewState extends State<ScheduleView> {
                                       onPressed: () {
                                         filteredScheduleModel
                                             .addSchedule(schedule);
-                                        scheduleModel.addSchedule(schedule);
+                                        service.addSchedule(
+                                            ScheduleDto.toScheduleDto(schedule, '1'), scheduleModel);
                                         print("call 되돌리기");
                                       },
                                     ),
@@ -205,14 +207,14 @@ class _ScheduleViewState extends State<ScheduleView> {
                         Provider.of<ScheduleModel>(context, listen: false);
                     if (schedule == null) {
                       // 중복된 일정을 추가하지 않도록 확인
-                      if (!scheduleModel.schedules.contains(newSchedule)) {
-                        scheduleModel.addSchedule(newSchedule);
+                      if (!scheduleModel.schedules.any((schedule) => schedule.id == newSchedule.id)) {
                         print(
                             "scheduleModel length: ${scheduleModel.schedules.length}");
-                        service.addMultipleSchedules(
-                            [ScheduleDto.toScheduleDto(newSchedule, '1')]);
+                        service.addSchedule(
+                            ScheduleDto.toScheduleDto(newSchedule, '1'), scheduleModel);
                       }
                     } else {
+                     service.updateSchedule(newSchedule.id, ScheduleDto.toScheduleDto(newSchedule, '1'));
                       scheduleModel.editSchedule(newSchedule);
                     }
                     Navigator.pop(context);

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -19,7 +19,7 @@ class ScheduleView extends StatefulWidget {
 
 class _ScheduleViewState extends State<ScheduleView> {
   int _selectedDay = 1;
-  DateTime? _selectedDate;
+  DateTime? _selectedDate = DateTime.now();
   String selectedFilter = 'Date';
   late ScheduleModel filteredScheduleModel = ScheduleModel();
   late ScheduleModel originScheduleModel;
@@ -33,7 +33,7 @@ class _ScheduleViewState extends State<ScheduleView> {
                 (DateFormat('yyyy-MM-dd HH:mm').parse(b.time)))); // 최신순
       } else if (filter == 'Name') {
         filteredScheduleModel.schedules
-            .sort((a, b) => b.title.compareTo(a.title)); // 최신순
+            .sort((a, b) => a.title.compareTo(b.title)); // 최신순
       }
     });
   }

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -38,14 +38,12 @@ class _ScheduleViewState extends State<ScheduleView> {
         filteredScheduleModel.schedules
             .sort((a, b) => a.title.compareTo(b.title)); // 최신순
       }
-      print("Filtering");
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final scheduleModel = Provider.of<ScheduleModel>(context);
-    print("build scheduleModel : ${scheduleModel.schedules.length}");
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
@@ -70,7 +68,6 @@ class _ScheduleViewState extends State<ScheduleView> {
                 filteredScheduleModel.addScheduleList(
                     ScheduleModel.schedulesForDate(
                         _selectedDate!, originScheduleList));
-                print("Day Selected");
               });
             },
           ),
@@ -101,16 +98,9 @@ class _ScheduleViewState extends State<ScheduleView> {
             child: Consumer<ScheduleModel>(
               builder: (context, scheduleModel, child) {
                 originScheduleList = scheduleModel.schedules;
-                print(
-                    "originScheduleModel length: ${originScheduleList.length}");
-                print(
-                    "scheduleModel length: ${scheduleModel.schedules.length}");
                 filteredScheduleModel.addScheduleList(
                     ScheduleModel.schedulesForDate(
                         _selectedDate!, originScheduleList));
-                if (originScheduleList.length == 159) {
-                  print("First 159");
-                }
                 return filteredScheduleModel.schedules.isEmpty
                     ? const Center(
                         child: Text(
@@ -145,8 +135,9 @@ class _ScheduleViewState extends State<ScheduleView> {
                                         filteredScheduleModel
                                             .addSchedule(schedule);
                                         service.addSchedule(
-                                            ScheduleDto.toScheduleDto(schedule, '1'), scheduleModel);
-                                        print("call 되돌리기");
+                                            ScheduleDto.toScheduleDto(
+                                                schedule, '1'),
+                                            scheduleModel);
                                       },
                                     ),
                                   ),
@@ -207,14 +198,15 @@ class _ScheduleViewState extends State<ScheduleView> {
                         Provider.of<ScheduleModel>(context, listen: false);
                     if (schedule == null) {
                       // 중복된 일정을 추가하지 않도록 확인
-                      if (!scheduleModel.schedules.any((schedule) => schedule.id == newSchedule.id)) {
-                        print(
-                            "scheduleModel length: ${scheduleModel.schedules.length}");
+                      if (!scheduleModel.schedules
+                          .any((schedule) => schedule.id == newSchedule.id)) {
                         service.addSchedule(
-                            ScheduleDto.toScheduleDto(newSchedule, '1'), scheduleModel);
+                            ScheduleDto.toScheduleDto(newSchedule, '1'),
+                            scheduleModel);
                       }
                     } else {
-                     service.updateSchedule(newSchedule.id, ScheduleDto.toScheduleDto(newSchedule, '1'));
+                      service.updateSchedule(newSchedule.id,
+                          ScheduleDto.toScheduleDto(newSchedule, '1'));
                       scheduleModel.editSchedule(newSchedule);
                     }
                     Navigator.pop(context);

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -105,6 +105,9 @@ class _ScheduleViewState extends State<ScheduleView> {
                     "originScheduleModel length: ${originScheduleList.length}");
                 print(
                     "scheduleModel length: ${scheduleModel.schedules.length}");
+                filteredScheduleModel.addScheduleList(
+                    ScheduleModel.schedulesForDate(
+                        _selectedDate!, originScheduleList));
                 if (originScheduleList.length == 159) {
                   print("First 159");
                 }

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -77,7 +77,6 @@ class _ScheduleViewState extends State<ScheduleView> {
               PopupMenuButton<String>(
                 onSelected: (value) {
                   _sortItems(value); // 정렬 함수 호출
-                  print("call _sortItems");
                 },
                 itemBuilder: (BuildContext context) => [
                   PopupMenuItem(
@@ -111,7 +110,6 @@ class _ScheduleViewState extends State<ScheduleView> {
                     : ListView.builder(
                         itemCount: filteredScheduleModel.schedules.length,
                         itemBuilder: (context, index) {
-                          print(filteredScheduleModel.schedules.length);
                           final schedule =
                               filteredScheduleModel.schedules[index];
                           return Padding(

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -78,6 +78,8 @@ class _ScheduleViewState extends State<ScheduleView> {
                 onSelected: (value) {
                   _sortItems(value); // 정렬 함수 호출
                 },
+                color: Colors.white,
+                offset: const Offset(-25, 40),
                 itemBuilder: (BuildContext context) => [
                   PopupMenuItem(
                     value: 'Date',

--- a/lib/screens/schedule_view.dart
+++ b/lib/screens/schedule_view.dart
@@ -28,7 +28,6 @@ class _ScheduleViewState extends State<ScheduleView> {
   late List<Schedule> originScheduleList;
 
   void _sortItems(String filter) {
-    setState(() {
       selectedFilter = filter;
       if (filter == 'Date') {
         filteredScheduleModel.schedules.sort((a, b) =>
@@ -38,7 +37,6 @@ class _ScheduleViewState extends State<ScheduleView> {
         filteredScheduleModel.schedules
             .sort((a, b) => a.title.compareTo(b.title)); // 최신순
       }
-    });
   }
 
   @override
@@ -77,6 +75,9 @@ class _ScheduleViewState extends State<ScheduleView> {
               PopupMenuButton<String>(
                 onSelected: (value) {
                   _sortItems(value); // 정렬 함수 호출
+                  setState(() {
+                    selectedFilter = value;
+                  });
                 },
                 color: Colors.white,
                 offset: const Offset(-25, 40),
@@ -102,6 +103,7 @@ class _ScheduleViewState extends State<ScheduleView> {
                 filteredScheduleModel.addScheduleList(
                     ScheduleModel.schedulesForDate(
                         _selectedDate!, originScheduleList));
+                _sortItems(selectedFilter);
                 return filteredScheduleModel.schedules.isEmpty
                     ? const Center(
                         child: Text(

--- a/lib/service/FirestoreScheduleService.dart
+++ b/lib/service/FirestoreScheduleService.dart
@@ -1,0 +1,94 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:overture/service/ScheduleDto.dart';
+
+class FirestoreScheduleService {
+  final CollectionReference _collectionRef =
+      FirebaseFirestore.instance.collection('schedules');
+
+  // 비동기로 Schedule 생성
+  Future<void> createSchedule(ScheduleDto schedule) async {
+    try {
+      await _collectionRef.add(schedule.toJson());
+      print('Schedule created successfully');
+    } catch (e) {
+      print('Error creating schedule: $e');
+      rethrow;
+    }
+  }
+
+  // ID로 Schedule 조회
+  Future<ScheduleDto?> getScheduleById(String id) async {
+    try {
+      DocumentSnapshot doc = await _collectionRef.doc(id).get();
+      if (doc.exists) {
+        return ScheduleDto.fromJson(doc.data() as Map<String, dynamic>);
+      } else {
+        print('No schedule found with ID: $id');
+        return null;
+      }
+    } catch (e) {
+      print('Error retrieving schedule: $e');
+      rethrow;
+    }
+  }
+
+  // Schedule 업데이트
+  Future<void> updateSchedule(String id, ScheduleDto updatedSchedule) async {
+    try {
+      await _collectionRef.doc(id).update(updatedSchedule.toJson());
+      print('Schedule updated successfully');
+    } catch (e) {
+      print('Error updating schedule: $e');
+      rethrow;
+    }
+  }
+
+  // Schedule 삭제
+  Future<void> deleteSchedule(String id) async {
+    try {
+      await _collectionRef.doc(id).delete();
+      print('Schedule deleted successfully');
+    } catch (e) {
+      print('Error deleting schedule: $e');
+      rethrow;
+    }
+  }
+
+  // 모든 Schedule 조회
+  Future<List<ScheduleDto>> getAllSchedules() async {
+    try {
+      QuerySnapshot querySnapshot = await _collectionRef.get();
+      return querySnapshot.docs
+          .map(
+              (doc) => ScheduleDto.fromJson(doc.data() as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      print('Error retrieving all schedules: $e');
+      rethrow;
+    }
+  }
+
+  // 병렬 처리 예시: 여러 Schedule 추가
+  Future<void> addMultipleSchedules(List<ScheduleDto> schedules) async {
+    try {
+      await Future.wait(schedules.map((schedule) =>
+          _collectionRef.add(schedule.toJson()))); // 병렬로 모든 스케줄 추가
+      print('All schedules added successfully');
+    } catch (e) {
+      print('Error adding multiple schedules: $e');
+      rethrow;
+    }
+  }
+
+  // 병렬 처리 예시: 여러 Schedule 삭제
+  Future<void> deleteMultipleSchedules(List<String> ids) async {
+    try {
+      await Future.wait(
+          ids.map((id) => _collectionRef.doc(id).delete())); // 병렬로 모든 스케줄 삭제
+      print('All schedules deleted successfully');
+    } catch (e) {
+      print('Error deleting multiple schedules: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/service/ScheduleDto.dart
+++ b/lib/service/ScheduleDto.dart
@@ -1,0 +1,54 @@
+import 'package:intl/intl.dart';
+import 'package:overture/models/schedule_model_files/schedule_model.dart';
+
+class ScheduleDto {
+  final String scheduleId;
+  final String userId;
+  final String title;
+  final String place;
+  final String time;
+  final String content;
+
+  ScheduleDto(
+      {required this.scheduleId,
+      required this.userId,
+      required this.title,
+      required this.place,
+      required this.time,
+      required this.content});
+
+  factory ScheduleDto.fromJson(Map<String, dynamic> json) {
+    return ScheduleDto(
+        scheduleId: json['scheduleId'],
+        userId: json['userId'],
+        title: json['title'],
+        place: json['place'],
+        time: json['time'],
+        content: json['content']);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'scheduleId': scheduleId,
+      'userId': userId,
+      'title': title,
+      'place': place,
+      'time': time,
+      'content': content
+    };
+  }
+
+  DateTime toDateTime() {
+    return DateFormat('yyyy-MM-dd HH:mm').parse(time);
+  }
+
+  static ScheduleDto toScheduleDto(Schedule schedule, String userId) {
+    return ScheduleDto(
+        scheduleId: schedule.id,
+        userId: userId,
+        title: schedule.title,
+        place: schedule.place,
+        time: schedule.time,
+        content: schedule.content);
+  }
+}

--- a/lib/service/ScheduleDto.dart
+++ b/lib/service/ScheduleDto.dart
@@ -51,4 +51,13 @@ class ScheduleDto {
         time: schedule.time,
         content: schedule.content);
   }
+
+  static Schedule toSchedule(ScheduleDto scheduleDto) {
+    return Schedule(
+        id: scheduleDto.scheduleId,
+        title: scheduleDto.title,
+        content: scheduleDto.content,
+        time: scheduleDto.time,
+        place: scheduleDto.place);
+  }
 }

--- a/lib/service/ScheduleDto.dart
+++ b/lib/service/ScheduleDto.dart
@@ -2,7 +2,7 @@ import 'package:intl/intl.dart';
 import 'package:overture/models/schedule_model_files/schedule_model.dart';
 
 class ScheduleDto {
-  final String scheduleId;
+  String scheduleId;
   final String userId;
   final String title;
   final String place;
@@ -17,9 +17,9 @@ class ScheduleDto {
       required this.time,
       required this.content});
 
-  factory ScheduleDto.fromJson(Map<String, dynamic> json) {
+  factory ScheduleDto.fromJson(Map<String, dynamic> json, String id) {
     return ScheduleDto(
-        scheduleId: json['scheduleId'],
+        scheduleId: id,
         userId: json['userId'],
         title: json['title'],
         place: json['place'],
@@ -59,5 +59,9 @@ class ScheduleDto {
         content: scheduleDto.content,
         time: scheduleDto.time,
         place: scheduleDto.place);
+  }
+
+  void updateScheduleId(String id) {
+    scheduleId = id;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "72.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: "71c01c1998c40b3af1944ad0a5f374b4e6fef7f3d2df487f3970dbeadaeb25a1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.46"
   _macros:
     dependency: transitive
     description: dart
@@ -142,6 +150,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      sha256: d5b73c5f27d95504e45d96e793fe9f9daa62e42b22da85b9f8de4916f46e916d
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.5.0"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      sha256: "8d5a3a501f3b21638199819ab76709d3b87abc9a565ed611b13a238611cfba27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      sha256: "24f302e4ffd88ec2891e33f432b53f59ebd072664c5dc804b7fcbc51ea22b4b3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.4"
   code_builder:
     dependency: transitive
     description:
@@ -294,6 +326,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+3"
+  firebase_core:
+    dependency: "direct main"
+    description:
+      name: firebase_core
+      sha256: "2438a75ad803e818ad3bd5df49137ee619c46b6fc7101f4dbc23da07305ce553"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.0"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: e30da58198a6d4b49d5bce4e852f985c32cb10db329ebef9473db2b9f09ce810
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: f967a7138f5d2ffb1ce15950e2a382924239eaa521150a8f144af34e68b3b3e5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.18.1"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,8 @@ dependencies:
   image_picker: ^1.1.2
   google_mlkit_text_recognition: ^0.14.0
   flutter_tts: ^4.2.0
+  cloud_firestore: ^5.5.0
+  firebase_core: ^3.8.0
 
 
 dev_dependencies:


### PR DESCRIPTION
- 파베 API 연동 - Collection Name : schedules
```
content (문자열)
: 일정 상세 내용
place "서울타워" (문자열)
: 위치 정보
scheduleId "rdiKDkvZzdBjOr46KOYM" (문자열)
: 해당 일정의 고유 ID
time "2024-12-03 16:22" (문자열)
: 일정 시각 YYYY-mm-dd MM:SS
* 일정 추가를 눌렀을 시점에서 일정에 클릭된 Day의 날짜로 설정됨. *
title "바닷가 불꽃놀이" (문자열)
: 일정 요약(제목)
userId "1" (문자열)
: 일정 소유자 (현재 1로 Fix)
```
- 필터링 기능 디버깅 완료
> 시간 순 디폴트
> 이름 순 가능
